### PR TITLE
feat: Use colorful gradients for all mode buttons

### DIFF
--- a/src/components/InteractivePanel.tsx
+++ b/src/components/InteractivePanel.tsx
@@ -459,7 +459,7 @@ export const InteractivePanel: React.FC = () => {
                       className={`px-3 sm:px-4 py-2 rounded-full text-xs sm:text-sm font-medium transition-all duration-200 transform hover:scale-105 flex items-center space-x-1 sm:space-x-2 ${
                         selectedService === service.id
                           ? `bg-gradient-to-r ${colors[service.id as keyof typeof colors]} text-white shadow-lg`
-                          : 'bg-gradient-to-r from-slate-600 to-slate-700 text-white/80 hover:text-white hover:from-slate-500 hover:to-slate-600 border border-transparent hover:border-white/20 backdrop-blur-sm'
+                          : `bg-gradient-to-r ${colors[service.id as keyof typeof colors]} text-white/80 opacity-60 hover:opacity-100`
                       }`}
                     >
                       <Icon className="w-3 h-3 sm:w-4 sm:h-4" />


### PR DESCRIPTION
This commit updates the styling of the mode selection buttons to use colorful gradients for all states, active and inactive.

- Inactive buttons now use their service-specific gradient but with a reduced opacity (`opacity-60`) to make them less prominent than the active button.
- Hovering over an inactive button restores its full opacity, providing clear visual feedback.
- This change creates a more vibrant and visually consistent user interface.