### PR TITLE
fix: Tune typography and line spacing

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -61,7 +61,7 @@ input, textarea {
 
 .prose p {
   margin-bottom: 1em;
-  line-height: 1.6;
+  line-height: 1.7;
 }
 
 .prose strong, .prose b {


### PR DESCRIPTION
This commit fine-tunes the typography based on your feedback.

- **Line Spacing**: The line-height for paragraph text inside the `.prose` class has been increased from 1.6 to 1.7 to give the text a more 'airy' and readable feel.
- **Verification**: Confirmed that the existing font and color choices (`Playfair Display`, `Montserrat`, and `#333333` text color) already align with your specifications.