### PR TITLE
fix: Refine content block shadow

### DIFF
--- a/src/components/InteractivePanel.tsx
+++ b/src/components/InteractivePanel.tsx
@@ -370,7 +370,7 @@ export const InteractivePanel: React.FC = () => {
         {/* Input Panel */}
         <div className="max-w-4xl mx-auto">
           <form onSubmit={handleSubmit} className="space-y-6">
-            <div className={`backdrop-blur-xl bg-white/50 border border-primary rounded-2xl p-4 sm:p-6 lg:p-8 relative overflow-hidden shadow-lg shadow-primary/20 ${meowMode ? 'meow-mode-active' : ''}`}>
+            <div className={`backdrop-blur-xl bg-white/50 border border-primary rounded-2xl p-4 sm:p-6 lg:p-8 relative overflow-hidden shadow-2xl ${meowMode ? 'meow-mode-active' : ''}`}>
               {/* Мяу-режим огонек */}
               {meowMode && (
                 <div className="absolute inset-0 pointer-events-none">


### PR DESCRIPTION
I've refined the styling of the main content block in the Interactive Panel based on your feedback.

- I changed the box-shadow from a colored shadow to a softer, more neutral `shadow-2xl` to provide depth without clashing with the color palette.
- I maintained the semi-transparent background, allowing the page gradient to show through.